### PR TITLE
Fixing derivative rule for a few trig functions

### DIFF
--- a/lib/@cada/cadaunarymath.m
+++ b/lib/@cada/cadaunarymath.m
@@ -132,21 +132,21 @@ switch callerstr
   case 'acot'
     dydx = ['-1./(1+',x,'.^2)'];
   case 'asec'
-    dydx = ['1./',x,'./','sqrt(',x,'.^2-1)'];
+    dydx = ['1./',x,'.^2./','sqrt(1-1./',x,'.^2)'];
   case 'acsc'
-    dydx = ['-1./',x,'./','sqrt(',x,'.^2-1)'];
+    dydx = ['-1./',x,'.^2./','sqrt(1-1./',x,'.^2)'];
   case 'sind'
-    dydx = ['180./pi.*cos(',x,')'];
+    dydx = ['pi/180.*cosd(',x,')'];
   case 'cosd'
-    dydx = ['-180./pi.*sin(',x,')'];
+    dydx = ['-pi/180.*sind(',x,')'];
   case 'tand'
-    dydx = ['180./pi.*sec(',x,').^2'];
+    dydx = ['pi/180.*secd(',x,').^2'];
   case 'cotd'
-    dydx = ['-180./pi.*csc(',x,').^2'];
+    dydx = ['-pi/180.*cscd(',x,').^2'];
   case 'secd'
-    dydx = ['180./pi.*sec(',x,').*tan(',x,')'];
+    dydx = ['pi/180.*secd(',x,').*tand(',x,')'];
   case 'cscd'
-    dydx = ['-180./pi.*csc(',x,').*cot(',x,')'];
+    dydx = ['-pi/180.*cscd(',x,').*cotd(',x,')'];
   case 'asind'
     dydx = ['180./pi./sqrt(1-',x,'.^2)'];
   case 'acosd'
@@ -156,9 +156,9 @@ switch callerstr
   case 'acotd'
     dydx = ['-180./pi./(1+',x,'.^2)'];
   case 'asecd'
-    dydx = ['180./pi./',x,'./','sqrt(',x,'.^2-1)'];
+    dydx = ['180./pi./',x,'.^2./','sqrt(1-1./',x,'.^2)'];
   case 'acscd'
-    dydx = ['-180./pi./',x,'./','sqrt(',x,'.^2-1)'];
+    dydx = ['-180./pi./',x,'.^2./','sqrt(1-1./',x,'.^2)'];
   case 'sinh'
     dydx = ['cosh(',x,')'];
   case 'cosh'
@@ -174,13 +174,13 @@ switch callerstr
   case 'asinh'
     dydx = ['1./sqrt(',x,'.^2+1)'];
   case 'acosh'
-    dydx = ['1./sqrt(',x,'.^2-1)'];
+    dydx = ['1./sqrt(',x,'-1)./sqrt(',x,'+1)'];
   case 'atanh'
     dydx = ['1./(1-',x,'.^2)'];
   case 'acoth'
     dydx = ['1./(1-',x,'.^2)'];
   case 'asech'
-    dydx = ['-1./',x,'./sqrt(1-',x,'.^2)'];
+    dydx = ['-1./',x,'.^2./sqrt(1./',x,'-1)./sqrt(1./',x,'+1)'];
   case 'acsch'
     dydx = ['-1./abs(',x,')./sqrt(1+',x,'.^2)'];
   case 'erf'

--- a/unit_tests/test_unarymath_rules.m
+++ b/unit_tests/test_unarymath_rules.m
@@ -1,0 +1,77 @@
+function violations = test_unarymath_rules()
+
+mkdir('tmp');
+addpath('tmp');
+fid = fopen('cadaunarymath.m','r');
+frewind(fid);
+
+l = fgetl(fid);
+while ~isnumeric(l)
+  if strcmp(strtrim(l),'function dydx = getdydx(x,callerstr)')
+    break;
+  end
+  l = fgetl(fid);
+end
+
+fnames = cell(1,0);
+while ~isnumeric(l)
+  l = strtrim(l);
+  if strncmp(l,'case',4)
+    tmp = strtrim(l(5:end));
+    fnames{end+1} = tmp(2:end-1); %#ok<AGROW>
+  end
+  l = fgetl(fid);
+end
+bad = zeros(size(fnames));
+for ii = 1:length(fnames)
+  bad(ii) = test_this(fnames{ii});
+end
+
+for ii = 1:length(fnames)
+  if bad(ii)
+    fprintf('%s - %d violations\n',fnames{ii},bad(ii));
+  end
+end
+violations = sum(bad);
+
+end
+
+function bad = test_this(fun)
+fname = ['test_',fun];
+ffname = ['tmp/',fname];
+fid2 = fopen([ffname,'.m'],'w+');
+fprintf(fid2,'function y = %s(x)\n',fname);
+fprintf(fid2,'y = %s(x);\n',fun);
+fprintf(fid2,'end\n');
+fclose(fid2);
+
+dname = [fname,'_dx'];
+rehash;
+ax = adigatorCreateDerivInput([1 1],'x');
+
+adigator(fname,{ax},dname,adigatorOptions('overwrite',1));
+movefile([dname,'.*'],'tmp/');
+bad = 0;
+
+xtest = [linspace(-0.9,0.9,10) linspace(-2*pi,2*pi,10) linspace(-360,360,10)];
+for ii = 1:length(xtest)
+  xx.f  = xtest(ii);
+  xx.dx = 1;
+  yy = feval(dname,xx);
+  
+  ee = 1e-6;
+  f1 = feval(fname,xx.f);
+  f2 = feval(fname,xx.f+ee);
+  df = (f2-f1)/ee;
+  if abs(yy.dx-df)/(1+abs(df)) > 1e-4
+    bad = bad + 1;
+    if isnan(f1) || isinf(f1) || abs(df) > 1e8
+      % Neglect these corner cases - finite difference as wrong as AD
+      bad = bad-1;
+    else
+      %keyboard
+    end
+  end
+end
+
+end


### PR DESCRIPTION
Most trig "degree" versions had errors, a few inverse functions had errors only on particular inputs (typically when dealing with imaginary results). Added a unit test for testing all unary math derivative rules.