### PR TITLE
Allow MATLAB PAUSE function

### DIFF
--- a/lib/adigatorPrintTempFiles.m
+++ b/lib/adigatorPrintTempFiles.m
@@ -488,6 +488,8 @@ while MajorLineCount <= EndLocation(1) && ~isnumeric(FunStrFULL)
         errlink = GenErrorLink(Ffid,MajorLineCount);
         error(['In order to load in variables, must assign them to a'...
           ' variable name. At ',FunStri,' ',errlink]);
+      elseif StrLength > 5 && strcmp(FunStri(1:6),'pause(')
+        % PAUSE
       else
         % Dont know what this statement is.
         errlink = GenErrorLink(Ffid,MajorLineCount);


### PR DESCRIPTION
This pull request is to modify Adigator to fix an annoying behavior when using Adigator with GPOPS-II.

The problem: When using Adigator with GPOPS-II and IPOPT, sometimes the
IPOPT log does not scroll continuously as one would expect. Adding a
very short pause to the Continuous.m function fixes that behavior, but
that causes an Adigator error. For example, if the GOPOS-II Continuous function is defined as

```
function output = gdrd07_Continuous(input)
pause(0.000001)

...

return
```
then running `gpops2` with the option `setup.derivatives.supplier = 'adigator';` produces the following error message:
```
Error using adigatorPrintTempFiles>PrintTemp (line 496)
Cannot process statement: pause(0.000001) at User's Function: gdrd07_Continuous.m line 2
Error in adigatorPrintTempFiles (line 41)
  PrintTemp(Ffid,StartLocation,EndLocation,Tfid,indent,FunStrChecks,DerNumber);
Error in adigator (line 416)
  [ForCount,IfCount] = adigatorPrintTempFiles(FunctionInfo(Fcount).File.fid,Tfid,...

Error in adigatorGenFiles4gpops2 (line 204)
adigator(ContFunc,{cinput},ContDeriv1,ADopts);
Error in gdrd07_Main (line 13)
adigatorfilenames = adigatorGenFiles4gpops2(setup); 
```
The change proposed here eliminates that error and produces the desired behavior.
