### PR TITLE
Temp Directory Location

### DIFF
--- a/adigator.m
+++ b/adigator.m
@@ -723,7 +723,7 @@ function [SoftwareLocation,adigatorTempDir] = filekeeping()
 SoftwareLocation = which('adigator');
 SoftwareLocation = SoftwareLocation(1:end-11);
 % Delete any previously created dummy files
-adigatorTempDir = [SoftwareLocation,filesep,'adigatorTempDir',filesep];
+adigatorTempDir = [pwd,filesep,'adigatorTempDir',filesep];
 if exist(adigatorTempDir,'dir')
   P = path;
   if ~isempty(strfind(P,[adigatorTempDir(1:end-1),':']))


### PR DESCRIPTION
If Adigator is installed on a multi-user machine on Linux, the natural place to put it is /opt/adigator. However, /opt/adigator is write-protected. Can the temporary directory be in the current MATLAB folder instead? I have tested this and it works just fine.